### PR TITLE
revert "cleanup unused queries"

### DIFF
--- a/src/entities/transaction/model.ts
+++ b/src/entities/transaction/model.ts
@@ -111,7 +111,7 @@ export function useUserTransactionsQuery<
   );
   watch(
     [() => toValue(userId), () => toValue(filterBy)],
-    ([newUserId, newFilterBy], _, onCleanup) => {
+    ([newUserId, newFilterBy]) => {
       settledQuery.value = setUserTransactionsQuery(
         queries,
         newUserId,
@@ -122,10 +122,6 @@ export function useUserTransactionsQuery<
           currency: populatedWith?.currency ?? false,
         }
       );
-
-      onCleanup(() => {
-        queries.delQueryDefinition(settledQuery.value.queryId);
-      });
     }
   );
 

--- a/src/entities/user/model.ts
+++ b/src/entities/user/model.ts
@@ -44,7 +44,6 @@ export function useCurrentUser() {
 
 export function useUsers() {
   const usersQuery = setUsersQuery();
-
   return useResultTable<Record<string, StoredUser>, StoreSchema>({
     queries,
     queryId: () => usersQuery.queryId,

--- a/src/entities/wallet/model.ts
+++ b/src/entities/wallet/model.ts
@@ -662,12 +662,9 @@ export function useUserWalletsQuery<
   );
   watch(
     () => toValue(userId),
-    (newUserId, _, onCleanup) => {
+    (newUserId) => {
       settledQuery.value = setUserWalletsQuery(queries, newUserId, {
         currency: true,
-      });
-      onCleanup(() => {
-        queries.delQueryDefinition(settledQuery.value.queryId);
       });
     }
   );

--- a/src/shared/lib/tiny-base/query.ts
+++ b/src/shared/lib/tiny-base/query.ts
@@ -58,12 +58,7 @@ export function useResultRowIds<TSchemas extends OptionalSchemas>(args: {
     () => toValue(queryId),
     (newQueryId) => {
       ids.value = queries.getResultRowIds(newQueryId);
-
-      onWatcherCleanup(() => {
-        queries.delQueryDefinition(newQueryId);
-      });
-    },
-    { immediate: true }
+    }
   );
 
   useResultRowIdsListener({
@@ -113,9 +108,8 @@ export function useResultRow<
   queryId: MaybeRefOrGetter<string>;
   rowId: MaybeRefOrGetter<Id>;
   queries: Queries<TSchemas>;
-  disableQueryCleanup?: boolean;
 }) {
-  const { queryId, rowId, queries, disableQueryCleanup } = args;
+  const { queryId, rowId, queries } = args;
   const row = shallowRef(
     queries.getResultRow(toValue(queryId), toValue(rowId)) as TResultRow
   );
@@ -124,12 +118,7 @@ export function useResultRow<
     [() => toValue(queryId), () => toValue(rowId)],
     ([newQueryId, newRowId]) => {
       row.value = queries.getResultRow(newQueryId, newRowId);
-
-      onWatcherCleanup(() => {
-        if (!disableQueryCleanup) queries.delQueryDefinition(newQueryId);
-      });
-    },
-    { immediate: true }
+    }
   );
 
   useResultRowListener({
@@ -177,17 +166,9 @@ export function useResultTable<
     queries.getResultTable(toValue(queryId)) as TResultTable
   );
 
-  watch(
-    [() => toValue(queryId)],
-    ([newQueryId]) => {
-      resultTable.value = queries.getResultTable(newQueryId);
-
-      onWatcherCleanup(() => {
-        queries.delQueryDefinition(newQueryId);
-      });
-    },
-    { immediate: true }
-  );
+  watch([() => toValue(queryId)], ([newQueryId]) => {
+    resultTable.value = queries.getResultTable(newQueryId);
+  });
 
   useResultTableListener({
     queries,

--- a/src/shared/lib/tiny-base/ui/ResultRowView.vue
+++ b/src/shared/lib/tiny-base/ui/ResultRowView.vue
@@ -15,7 +15,6 @@ const row = useResultRow({
   queries: props.queries,
   queryId: toRef(() => props.queryId),
   rowId: toRef(() => props.rowId),
-  disableQueryCleanup: true,
 });
 </script>
 


### PR DESCRIPTION
Reason: too error prone

Known issues:
- empty categories on CategoriesDialog re-open
- empty wallet balance on WalletDialog re-open

This reverts commit c08010b86e27fd54ec3889c51db3506f9261bdea and some changes from 60cf3325448bfe89bce17d58efe485d5ea2fc42a.